### PR TITLE
add macvimswitch cask

### DIFF
--- a/Casks/macvimswitch.rb
+++ b/Casks/macvimswitch.rb
@@ -1,0 +1,21 @@
+cask "macvimswitch" do
+  version "0.6.4"
+  sha256 "728da4d886c9364b3e4c44278a6725b65f65071a838b84f8ee9c2b588b5b04f3"
+
+  url "https://github.com/Jackiexiao/macvimswitch/releases/download/v#{version}/MacVimSwitch.dmg"
+  name "MacVimSwitch"
+  desc "Input Source switcher for vim user"
+  homepage "https://github.com/Jackiexiao/macvimswitch/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "MacVimSwitch.app"
+
+  zap trash: "~/Library/Preferences/com.jackiexiao.macvimswitch.plist"
+end


### PR DESCRIPTION
Already verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] brew audit --cask --online <cask> is error-free.
- [x] brew style --fix <cask> reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] brew audit --cask --new <cask> worked successfully.
- [x] HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask> worked successfully.
- [x] brew uninstall --cask <cask> worked successfully.